### PR TITLE
Calculate shares with multiplier

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -42,5 +42,7 @@ class Cli:
     
     def calculate_shares(self):
         for person in self.personal_points:
-            share = (person[1] / self.total_points) * 100
+            standing = list(filter(lambda p: p['name'] == person[0], self.data.people))[0]['standing']
+            multiplier = float(list(filter(lambda m: m['name'] == standing, self.data.standings))[0]['rate'])
+            share = person[1] * multiplier / self.total_points * 100
             print(f"{person[0]} -> {share}%")

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,3 +1,4 @@
+import math
 from orgdata import OrgData
 
 
@@ -36,13 +37,17 @@ class Cli:
         for rating in ratings:
             frags = rating.split(' ')
             name = frags[0]
-            points = sum(list(map(int, frags[1:])))
+            standing = list(filter(lambda p: p['name'] == name, self.data.people))[0]['standing']
+            multiplier = float(list(filter(lambda m: m['name'] == standing, self.data.standings))[0]['rate'])
+            points = sum(list(map(int, frags[1:]))) * multiplier
             self.personal_points.append((name, points))
             self.total_points += points
     
     def calculate_shares(self):
+        remainder = 0.0
         for person in self.personal_points:
-            standing = list(filter(lambda p: p['name'] == person[0], self.data.people))[0]['standing']
-            multiplier = float(list(filter(lambda m: m['name'] == standing, self.data.standings))[0]['rate'])
-            share = person[1] * multiplier / self.total_points * 100
-            print(f"{person[0]} -> {share}%")
+            share = person[1] / self.total_points * 100
+            truncated_share = math.trunc(share)
+            remainder += share - truncated_share
+            print(f"{person[0]} -> {truncated_share}%")
+        print(f"Remainder -> {remainder}%")


### PR DESCRIPTION
Use standing multipliers when calculating shares. Also truncate shares to compute a remainder that is split evenly among the people. Related to issue #6 